### PR TITLE
Allow all the http-kit options to pass through.

### DIFF
--- a/src/untangled/server/impl/components/web_server.clj
+++ b/src/untangled/server/impl/components/web_server.clj
@@ -8,21 +8,20 @@
 (defrecord WebServer [port handler server]
   component/Lifecycle
   (start [component] []
-    (timbre/info "Web server started successfully."
-      (when (env :dev) "(using the development profile)"))
-    (try
-      (assoc component :server (run-server (:all-routes (:handler component))
-                                 {:port (-> component :config :value :port) :join? false}))
-      (catch Exception e
-        (timbre/fatal "Failed to start web server " e))
-      )
-    )
+    (let [http-kit-opts [:ip :port :thread :worker-name-prefix
+                         :queue-size :max-body :max-line]
+          server-opts (select-keys (-> component :config :value)
+                                   http-kit-opts)]
+      (timbre/info (str "Web server started successfully."
+                        (if (env :dev) (timbre/info "(using the development profile)")))
+                   "With options:" server-opts)
+      (try
+        (assoc component :server (run-server (:all-routes (:handler component))
+                                             server-opts))
+        (catch Exception e
+          (timbre/fatal "Failed to start web server " e)))))
   (stop [component] []
     (when-let [server (:server component)]
       (server)
       (timbre/info "web server stopped.")
-      (assoc component :server nil))
-    )
-  )
-
-
+      (assoc component :server nil))))


### PR DESCRIPTION
Specify all the http-kit config parameters, the same way `:port` was handled previously. Removed the `:join?` parameter since it is not used in http-kit.

http://www.http-kit.org/server.html

Also I wrapped the log string in `str` to avoid logging `nil`.

https://github.com/untangled-web/untangled-server/issues/4
