### PR TITLE
Added stacktrace to the error log statement

### DIFF
--- a/src/untangled/server/impl/components/handler.clj
+++ b/src/untangled/server/impl/components/handler.clj
@@ -70,7 +70,7 @@
                          (instance? ExceptionInfo error) (parser-read-error->response error)
                          (instance? Exception error) (unknow-error->response error)
                          :else (parser-mutate-error->response error))]
-    (timbre/error "Parser error:\n" (with-out-str (clojure.pprint/pprint error-response)))
+    (timbre/error error-response "Parser error:\n" (with-out-str (clojure.pprint/pprint error-response)))
     error-response))
 
 (defn valid-response? [result]


### PR DESCRIPTION
I changed the log statement to take advantage of the timbre [feature](https://github.com/ptaoussanis/timbre#logging) which logs the stacktrace for you if you pass in the exception as the first argument.
