### PR TITLE
Having :app-name string allows each application to `<domain>/<app-name>/api` rather than `<domain>/api`

### DIFF
--- a/specs/untangled/server/impl/components/handler_spec.clj
+++ b/specs/untangled/server/impl/components/handler_spec.clj
@@ -116,7 +116,7 @@
 (def run #(%1 %2))
 (specification "the handler"
   (behavior "takes an extra-routes map containing bidi :routes & :handlers"
-    (let [make-handler (fn [extra-routes] (h/handler (constantly nil) {} extra-routes identity identity))]
+    (let [make-handler (fn [extra-routes] (h/handler (constantly nil) {} extra-routes identity identity identity))]
       (assertions
         (-> {:routes   ["test" :test]
              :handlers {:test (fn [env match]

--- a/src/untangled/server/core.clj
+++ b/src/untangled/server/core.clj
@@ -107,15 +107,18 @@
                         and handlers are map from handler name to a function of type :: Env -> BidiMatch -> Res
                         see `handler/wrap-extra-routes` & handler-spec for more.
 
+  *`app-name`           OPTIONAL, a string that will turn \"\\api\" into \"<app-name>\\api\"
+
   Returns a Sierra system component.
   "
-  [& {:keys [config-path components parser parser-injections extra-routes]
+  [& {:keys [config-path components parser parser-injections extra-routes app-name]
       :or {config-path "/usr/local/etc/untangled.edn"}}]
   {:pre [(some-> parser fn?)
          (or (nil? components) (map? components))
          (or (nil? parser-injections) (every? keyword? parser-injections))]}
   (let [handler (handler/build-handler parser parser-injections
-                                       :extra-routes extra-routes)
+                                       :extra-routes extra-routes
+                                       :app-name app-name)
         built-in-components [:config (new-config config-path)
                              :handler handler
                              :server (make-web-server)]


### PR DESCRIPTION
This change makes it easier to have multiple Untangled applications all running on the same server-machine. Untangled-client does not need to be changed because it is configurable enough - when calling `new-untangled-client` have `:networking` set to `(net/make-untangled-network specific-url :global-error-callback (constantly nil))`, where specific-url is something like "my-app-name/api" and "my-app-name" is what `app-name` is on the untangled-server.
