### PR TITLE
Manipulate response handlers adjusts

### DIFF
--- a/src/untangled/server/core.clj
+++ b/src/untangled/server/core.clj
@@ -24,7 +24,7 @@
   [a->b b->c]
   (reduce (fn [result k] (assoc result k (->> k (get a->b) (get b->c)))) {} (keys a->b)))
 
-(defn augment-response [core-response ring-response-fn]
+(defn augment-response
   "Augments the Ring response that's returned from the handler.
 
   Use this function when you need to add information into the handler response, for
@@ -39,9 +39,10 @@
              ))})
 
   If your parser has multiple responses with `augment-response`, they will be applied
-  in order, the first one will receive an empty map as input. Only root keys of your
-  response will be checked for augmented response.
-  "
+  in order, the first one will receive an empty map as input. Only top level values
+  of your response will be checked for augmented response."
+  [core-response ring-response-fn]
+  (assert (instance? clojure.lang.IObj core-response) "Scalar values can't be augmented.")
   (with-meta core-response {::augment-response ring-response-fn}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/untangled/server/impl/components/handler.clj
+++ b/src/untangled/server/impl/components/handler.clj
@@ -82,8 +82,11 @@
               (assoc acc k v)))
     {} resp))
 
-(defn collect-response [data]
-  (->> (keep #(some-> (second %) meta :untangled.server.core/augment-response) data)
+(defn augment-map
+  "Parses response the top level values processing the augmented response. This function
+  expects the parser mutation results to be raised (use the raise-response function)."
+  [response]
+  (->> (keep #(some-> (second %) meta :untangled.server.core/augment-response) response)
        (reduce (fn [response f] (f response)) {})))
 
 (defn api
@@ -95,7 +98,7 @@
   [{:keys [transit-params parser env] :as req}]
   (let [parse-result (try (raise-response (parser env transit-params)) (catch Exception e e))]
     (if (valid-response? parse-result)
-      (merge {:status 200 :body parse-result} (collect-response parse-result))
+      (merge {:status 200 :body parse-result} (augment-map parse-result))
       (process-errors parse-result))))
 
 (defn generate-response


### PR DESCRIPTION
added the pre-condition, I used an assertion instead of a `:pre` because otherwise, the information would be confusing.

Also renamed `collect-response` to `augment-map`, this function can be useful for testing.