### PR TITLE
generate response needs to send down extra keys from api response

### DIFF
--- a/specs/untangled/server/impl/components/handler_spec.clj
+++ b/specs/untangled/server/impl/components/handler_spec.clj
@@ -16,11 +16,19 @@
 (specification "generate-response"
   (assertions
     "returns a map with status, header, and body."
-    (keys (h/generate-response {})) => [:status :headers :body]
+    (keys (h/generate-response {})) => [:status :body :headers]
 
     "merges Content-Type of transit json to the passed-in headers."
     (:headers (h/generate-response {:headers {:my :header}})) => {:my            :header
-                                                                  "Content-Type" "application/transit+json"})
+                                                                  "Content-Type" "application/transit+json"}
+
+    "preserves extra response keys from input"
+    (h/generate-response {:status 200 :body {} :session {:user-id 123}})
+    => {:status  200
+        :headers {"Content-Type" "application/transit+json"}
+        :body    {}
+        :session {:user-id 123}})
+
   (behavior "does not permit"
     (assertions
       "a \"Content-Type\" key in the header."

--- a/src/untangled/server/impl/components/handler.clj
+++ b/src/untangled/server/impl/components/handler.clj
@@ -108,9 +108,8 @@
   [{:keys [status body headers] :or {status 200} :as input}]
   {:pre [(not (contains? headers "Content-Type"))
          (and (>= status 100) (< status 600))]}
-  {:status  status
-   :headers (merge headers {"Content-Type" "application/transit+json"})
-   :body    body})
+  (-> (assoc input :status status :body body)
+      (update :headers assoc "Content-Type" "application/transit+json")))
 
 (def default-api-key "/api")
 


### PR DESCRIPTION
Today I got to use the augment feature, and realized there is a missing piece, currently the `generate-response` is constraining the keys, making the augmentation to de discarded.